### PR TITLE
Added memory requests for the Solrserver and Jobserver

### DIFF
--- a/nlp/pods/jobserver.yaml
+++ b/nlp/pods/jobserver.yaml
@@ -49,13 +49,12 @@ spec:
           #     port: 8084
           #   initialDelaySeconds: 60
           #   periodSeconds: 60
-          resources:
-              requests:
-                  memory: "8Gi"
           volumeMounts:
             - name: jobs-persistent-storage
               mountPath: /opt/jobWork/
               subPath: jobs
+      nodeSelector:
+          joborsolr: job
       volumes:
       - name: jobs-persistent-storage
         persistentVolumeClaim:

--- a/nlp/pods/jobserver.yaml
+++ b/nlp/pods/jobserver.yaml
@@ -49,6 +49,9 @@ spec:
           #     port: 8084
           #   initialDelaySeconds: 60
           #   periodSeconds: 60
+          resources:
+              requests:
+                  memory: "8Gi"
           volumeMounts:
             - name: jobs-persistent-storage
               mountPath: /opt/jobWork/

--- a/nlp/pods/solrserver.yaml
+++ b/nlp/pods/solrserver.yaml
@@ -56,9 +56,8 @@ spec:
           #   initialDelaySeconds: 5
           #   periodSeconds: 5
           #   failureThreshold: 30          
-          resources:
-              requests:
-                  memory: "8Gi"
+      nodeSelector:
+          joborsolr: solr
       # give pod more time to finish solr indexing
       terminationGracePeriodSeconds: 10      
       volumes:

--- a/nlp/pods/solrserver.yaml
+++ b/nlp/pods/solrserver.yaml
@@ -56,6 +56,9 @@ spec:
           #   initialDelaySeconds: 5
           #   periodSeconds: 5
           #   failureThreshold: 30          
+          resources:
+              requests:
+                  memory: "8Gi"
       # give pod more time to finish solr indexing
       terminationGracePeriodSeconds: 10      
       volumes:


### PR DESCRIPTION
The solrserver and jobserver are often getting scheduled on the same VM, but they both consume a lot of memory ~4-8 GB while the other pods consume very little. I thought that an easy way to make sure they get scheduled on different VMs would be to request 8Gi each since the VMs only have 14GB of memory.