### PR TITLE
Changed the jobserver pod configuration to a cronjob

### DIFF
--- a/nlp/pods/jobserver.yaml
+++ b/nlp/pods/jobserver.yaml
@@ -1,4 +1,4 @@
-kind: Deployment
+kind: CronJob #Set as a cronjob to enable automatic restarting of the pod to clear the jobserver memory. See nlp.patientsafety.regenstrief issue #8
 apiVersion: extensions/v1beta1
 metadata:
   name: fabric.nlp.jobserver
@@ -6,56 +6,49 @@ metadata:
   labels:
     app: jobserver
 spec:
-  replicas: 1
-  revisionHistoryLimit: 3  # Clean-up old Replica Sets deployed; only keep previous 3.
-  strategy:
-    # We need to kill the existing Pod before creating an new one
-    # for the new one to be able to attach the persistent disk.
-    type: Recreate        
-  selector:
-    matchLabels:
-      app: jobserver
-  template:
-    metadata:
-      labels:
-        app: jobserver
+  schedule: "0 0 * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: jobserver
-          image: healthcatalyst/fabric.nlp.docker.jobs:1
-          imagePullPolicy: Always          
-          env:
-            - name: NLPWEB_EXTERNAL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: nlpweb-external-url
-                  key: value
-            - name: JOBSERVER_EXTERNAL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: jobserver-external-url
-                  key: value
-            - name: MYSQL_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mysqlpassword
-                  key: password
-          ports:
-            - containerPort: 8084
-              name: jobserver
-          # livenessProbe:
-          #   httpGet:
-          #     path: /nlp
-          #     port: 8084
-          #   initialDelaySeconds: 60
-          #   periodSeconds: 60
-          volumeMounts:
-            - name: jobs-persistent-storage
-              mountPath: /opt/jobWork/
-              subPath: jobs
-      nodeSelector:
-          joborsolr: job
-      volumes:
-      - name: jobs-persistent-storage
-        persistentVolumeClaim:
-          claimName: nlp.jobserver            
+      activeDeadlineSeconds: 86400 
+      template:
+        spec:
+          containers:
+            - name: jobserver
+              image: healthcatalyst/fabric.nlp.docker.jobs:1
+              imagePullPolicy: Always          
+              env:
+                - name: NLPWEB_EXTERNAL_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: nlpweb-external-url
+                      key: value
+                - name: JOBSERVER_EXTERNAL_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: jobserver-external-url
+                      key: value
+                - name: MYSQL_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: mysqlpassword
+                      key: password
+              ports:
+                - containerPort: 8084
+                  name: jobserver
+              # livenessProbe:
+              #   httpGet:
+              #     path: /nlp
+              #     port: 8084
+              #   initialDelaySeconds: 60
+              #   periodSeconds: 60
+              volumeMounts:
+                - name: jobs-persistent-storage
+                  mountPath: /opt/jobWork/
+                  subPath: jobs
+          restartPolicy: Always
+          nodeSelector:
+              joborsolr: job
+          volumes:
+          - name: jobs-persistent-storage
+            persistentVolumeClaim:
+              claimName: nlp.jobserver            


### PR DESCRIPTION
I edited the nlp/pods/jobserver.yaml to make it a cronjob config. I figured it would still make sense to keep it in the pods directory rather than moving it to the jobs directory, but I can move it around.